### PR TITLE
fix: resolve buy-auth 500 errors with sequential processing and retry…

### DIFF
--- a/kognys/utils/aip_init.py
+++ b/kognys/utils/aip_init.py
@@ -84,14 +84,29 @@ def initialize_aip_agents():
             (AIP_ORCHESTRATOR_ID, AIP_SYNTHESIZER_ID),
         ]
         
-        for buyer, seller in auth_pairs:
+        for i, (buyer, seller) in enumerate(auth_pairs):
             if buyer in created_agents and seller in created_agents:
                 try:
+                    # Add delay between authorization calls to prevent nonce conflicts
+                    if i > 0:
+                        print(f"  - Waiting 2s before next authorization...")
+                        import time
+                        time.sleep(2)
+                    
                     success = buy_agent_auth(buyer, seller)
                     if success:
                         print(f"  - ✅ {buyer} authorized to access {seller}")
+                    else:
+                        print(f"  - ❌ Authorization failed: {buyer} → {seller}")
                 except Exception as e:
                     print(f"  - ⚠️  Auth failed: {buyer} → {seller}: {e}")
+            else:
+                missing_agents = []
+                if buyer not in created_agents:
+                    missing_agents.append(f"buyer '{buyer}'")
+                if seller not in created_agents:
+                    missing_agents.append(f"seller '{seller}'")
+                print(f"  - ⚠️  Skipping auth {buyer} → {seller}: {' and '.join(missing_agents)} not created")
     
     print(f"\n--- AIP initialization complete: {len(created_agents)}/{len(agents)} agents ready ---")
     return len(created_agents) > 0


### PR DESCRIPTION
… logic

- Add retry logic with exponential backoff (3s, 6s, 9s) for buy_agent_auth
- Fix concurrent authorization calls causing blockchain nonce conflicts
- Add sequential processing with 2s delays between authorization attempts
- Improve validation to prevent self-authorization and missing agent scenarios
- Add comprehensive error handling with response details and transaction hashes
- Add detailed logging for authorization skipping when agents don't exist

Fixes the multiple 500 Internal Server Error responses on /api/v1/agents/buy-auth

🤖 Generated with [Claude Code](https://claude.ai/code)